### PR TITLE
简化逻辑，直接访问路由属性

### DIFF
--- a/src/RouteConfig/useRouteBreadcrumbItems.ts
+++ b/src/RouteConfig/useRouteBreadcrumbItems.ts
@@ -4,30 +4,19 @@ import {useMemo} from 'react';
 import {RouteObject, PartialRouteMatch} from './interface';
 
 // eslint-disable-next-line max-len
-const getBreadcrumbItemsFromRoute = (routes: RouteObject[], routeMatches: PartialRouteMatch[] | null): BreadcrumbItemType[] => {
+const getBreadcrumbItemsFromRoute = (routeMatches: PartialRouteMatch[] | null): BreadcrumbItemType[] => {
     if (!routeMatches) {
         return [];
     }
-    let currentRoutes = routes;
     const items: BreadcrumbItemType[] = [];
-    // eslint-disable-next-line @typescript-eslint/prefer-for-of
-    for (let i = 0; i < routeMatches.length; i++) {
-        const routeMatch = routeMatches[i];
-        const nextRoute = currentRoutes.find(route => route.path === routeMatch.route.path);
-        if (!nextRoute) {
-            return items;
-        }
-        if (nextRoute?.breadcrumbProps) {
-            items.push(nextRoute.breadcrumbProps);
-        }
-        else if (nextRoute?.breadcrumb) {
-            items.push({title: nextRoute.breadcrumb});
-        }
-        if (nextRoute?.children) {
-            currentRoutes = nextRoute?.children;
-        }
-        else {
-            return items;
+
+    for (const match of routeMatches) {
+        const route = match.route as RouteObject;
+
+        if (route.breadcrumbProps) {
+            items.push(route.breadcrumbProps);
+        } else if (route.breadcrumb) {
+            items.push({title: route.breadcrumb});
         }
     }
     return items;
@@ -38,8 +27,7 @@ export const useRouteBreadcrumbItems = (routes: RouteObject[]) => {
     return useMemo(
         () => {
             const routeMatches = matchRoutes(routes, location);
-            const items = getBreadcrumbItemsFromRoute(routes, routeMatches);
-            return items;
+            return getBreadcrumbItemsFromRoute(routeMatches);
         },
         [location, routes]
     );

--- a/src/RouteConfig/useRouteDocumentTitle.ts
+++ b/src/RouteConfig/useRouteDocumentTitle.ts
@@ -3,34 +3,25 @@ import {useMemo} from 'react';
 import {DocumentTitleContext, RouteObject, PartialRouteMatch} from './interface';
 
 // eslint-disable-next-line max-len
-const getDocumentTitleFromRoute = (routes: RouteObject[], routeMatches: PartialRouteMatch[] | null, context?: DocumentTitleContext): string[] => {
+const getDocumentTitleFromRoute = (routeMatches: PartialRouteMatch[] | null, context?: DocumentTitleContext): string[] => {
     if (!routeMatches) {
         return [];
     }
-    let currentRoutes = routes;
+
     const items: string[] = [];
-    // eslint-disable-next-line @typescript-eslint/prefer-for-of
-    for (let i = 0; i < routeMatches.length; i++) {
-        const routeMatch = routeMatches[i];
-        const nextRoute = currentRoutes.find(route => route.path === routeMatch.route.path);
-        if (!nextRoute) {
-            return items;
-        }
-        let documentTitle = nextRoute?.documentTitle;
-        if (nextRoute?.documentTitleKey) {
-            const nextDocumentTitle = context?.[nextRoute?.documentTitleKey];
+
+    for (const match of routeMatches) {
+        const route = match.route as RouteObject;
+        let documentTitle = route.documentTitle;
+
+        if (route.documentTitleKey) {
+            const nextDocumentTitle = context?.[route.documentTitleKey];
             if (nextDocumentTitle) {
                 documentTitle = nextDocumentTitle;
             }
         }
         if (documentTitle) {
             items.push(documentTitle);
-        }
-        if (nextRoute?.children) {
-            currentRoutes = nextRoute?.children;
-        }
-        else {
-            return items;
         }
     }
     return items;
@@ -41,7 +32,7 @@ export const useRouteDocumentTitle = (routes: RouteObject[], context?: DocumentT
     return useMemo(
         () => {
             const routeMatches = matchRoutes(routes, location);
-            const items = getDocumentTitleFromRoute(routes, routeMatches, context);
+            const items = getDocumentTitleFromRoute(routeMatches, context);
             return items.join('-');
         },
         [context, location, routes]


### PR DESCRIPTION
解决了在嵌套路由中，如果有中间路由节点未定义 path 属性，则面包屑无法正常显示的问题。
通过直接访问路由属性，避免了对 routes 的依赖，简化了代码逻辑，增强了代码的健壮性和可维护性。